### PR TITLE
Minor cleanup and correct usage of UUID datatype and functions

### DIFF
--- a/migrations/001_initial.down.sql
+++ b/migrations/001_initial.down.sql
@@ -6,5 +6,4 @@ DROP TABLE audits;
 
 -- functions
 DROP FUNCTION IF EXISTS update_datetime();
-DROP FUNCTION IF EXISTS UUID();
 DROP FUNCTION IF EXISTS update_audit();


### PR DESCRIPTION
Minor cleanup and correct usage of UUID datatype and functions. Also set storage of JSONB columns on "objects" and "audit" tables using type "EXTERNAL" for improve I/O without need compress/uncompress.
